### PR TITLE
Add DFPriors (NeurIPS 2023) to visual SLAM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For an overview of **NeRFs**, checkout the Survey ([Neural Volume Rendering: NeR
 * End-to-End RGB-D SLAM With Multi-MLPs Dense Neural Implicit Representations, *RAL, 2023*. [[Paper](https://ieeexplore.ieee.org/abstract/document/10238793)]
 * **HI-SLAM**: Monocular Real-time Dense Mapping with Hybrid Implicit Fields, *arXiv, 2023*. [[Paper](https://arxiv.org/pdf/2310.04787.pdf)]
 * **CP-SLAM**: Collaborative Neural Point-based SLAM, *NeurIPS, 2023*. [[Paper](https://openreview.net/pdf?id=dFSeZm6dTC)]
+* Learning Neural Implicit through Volume Rendering with Attentive Depth Fusion Priors,  *NeurIPS, 2023*. [[Paper](https://arxiv.org/pdf/2310.11598.pdf)] [[Code](https://github.com/MachinePerceptionLab/Attentive_DFPrior)] [[Website](https://machineperceptionlab.github.io/Attentive_DF_Prior/)]
 * **NGEL-SLAM**: Neural Implicit Representation-based Global Consistent Low-Latency SLAM System, *arXiv, 2023*. [[Paper](https://arxiv.org/pdf/2311.09525.pdf)]
 * **SNI-SLAM**: Semantic Neural Implicit SLAM, *arXiv, 2023*. [[Paper](https://arxiv.org/pdf/2311.11016.pdf)]
 * Implicit Event-RGBD Neural SLAM, *arXiv, 2023*. [[Paper](https://arxiv.org/pdf/2311.11013.pdf)]


### PR DESCRIPTION
@DoongLi 

Hi, thanks for your awesome organization!

I have added a paper, 'Learning Neural Implicit through Volume Rendering with Attentive Depth Fusion Priors, NeurIPS, 2023.', to Visual SLAM section.
